### PR TITLE
Schema updates

### DIFF
--- a/acquisition.json
+++ b/acquisition.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/acquisition.json",
   "title": "Acquisition-level metadata (within dataset)",
   "description": "Acquisition",

--- a/dataset.json
+++ b/dataset.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/dataset.json",
   "title": "Dataset-level metadata",
   "description": "Dataset-level metadata is metadata concerning one specific, per-participant dataset",

--- a/dataset.json
+++ b/dataset.json
@@ -1,40 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/dataset.json",
-  "definitions": {
-    "person": {
-      "title": "Person",
-      "type": "object",
-      "properties": {
-        "name": { "title": "Name", "type": "string" },
-        "role": {
-          "title": "Role",
-          "description": "Role ID according to the Contributor Role Ontology (https://www.ebi.ac.uk/ols/ontologies/cro)",
-          "type": "string",
-          "pattern": "^((CRO_[0-9]{7})|(CREDIT_[0-9]{8}))$"
-        },
-        "email": { "title": "Email", "type": "string", "format": "idn-email" },
-        "orcid": {
-          "title": "ORCID identifier",
-          "description": "ORCID identifier",
-          "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}$"
-        },
-        "institution": {
-          "title": "Institution",
-          "type": "object",
-          "properties": {
-            "name": { "title": "Name", "type": "string" },
-            "street_address": { "title": "Street address", "type": "string" },
-            "city": { "title": "City", "type": "string" },
-            "country": { "title": "Country", "type": "string" }
-          },
-          "required": ["name", "country"]
-        }
-      },
-      "required": ["name", "role", "institution"]
-    }
-  },
   "title": "Dataset-level metadata",
   "description": "Dataset-level metadata is metadata concerning one specific, per-participant dataset",
   "type": "object",
@@ -82,7 +48,7 @@
       "title": "Contributors",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/person"
+        "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/person.json"
       }
     },
     "data_set": {

--- a/dataset.json
+++ b/dataset.json
@@ -70,7 +70,8 @@
             "ongoing": {
               "title": "Ongoing?",
               "description": "Indicate if the data collection is still ongoing",
-              "type": "boolean"
+              "type": "boolean",
+              "default": true
             }
           },
           "dependencies": {

--- a/dataset.json
+++ b/dataset.json
@@ -20,10 +20,10 @@
         "institution": {
           "type": "object",
           "properties": {
-            "name":           { "type": "string" },
+            "name": { "type": "string" },
             "street_address": { "type": "string" },
-            "city":           { "type": "string" },
-            "country":        { "type": "string" }
+            "city": { "type": "string" },
+            "country": { "type": "string" }
           },
           "required": ["name", "country"]
         }
@@ -68,7 +68,7 @@
       },
       "required": ["wear_time"]
     },
-    "contributors": { "$ref": "#/definitions/person"},
+    "contributors": { "$ref": "#/definitions/person" },
     "data_set": {
       "description": "Information about the data collection effort.",
       "type": "object",
@@ -104,5 +104,5 @@
       "required": ["period", "contributors"]
     }
   },
-  "required": [ "data_owner", "studyid", "uuid", "clinical_trial", "sample", "description", "keywords", "instructions", "data_collection"]
+  "required": ["uuid", "description", "instructions"]
 }

--- a/dataset.json
+++ b/dataset.json
@@ -101,8 +101,8 @@
           }
         }
       },
-      "required": ["period", "contributors"]
+      "required": ["period"]
     }
   },
-  "required": ["uuid", "description", "instructions"]
+  "required": ["uuid", "description", "instructions", "contributors"]
 }

--- a/dataset.json
+++ b/dataset.json
@@ -3,27 +3,31 @@
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/dataset.json",
   "definitions": {
     "person": {
+      "title": "Person",
       "type": "object",
       "properties": {
-        "name": { "type": "string" },
+        "name": { "title": "Name", "type": "string" },
         "role": {
+          "title": "Role",
           "description": "Role ID according to the Contributor Role Ontology (https://www.ebi.ac.uk/ols/ontologies/cro)",
           "type": "string",
           "pattern": "^((CRO_[0-9]{7})|(CREDIT_[0-9]{8}))$"
         },
-        "email": { "type": "string", "format": "idn-email" },
+        "email": { "title": "Email", "type": "string", "format": "idn-email" },
         "orcid": {
+          "title": "ORCID identifier",
           "description": "ORCID identifier",
           "type": "string",
           "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}$"
         },
         "institution": {
+          "title": "Institution",
           "type": "object",
           "properties": {
-            "name": { "type": "string" },
-            "street_address": { "type": "string" },
-            "city": { "type": "string" },
-            "country": { "type": "string" }
+            "name": { "title": "Name", "type": "string" },
+            "street_address": { "title": "Street address", "type": "string" },
+            "city": { "title": "City", "type": "string" },
+            "country": { "title": "Country", "type": "string" }
           },
           "required": ["name", "country"]
         }
@@ -36,30 +40,36 @@
   "type": "object",
   "properties": {
     "name": {
+      "title": "Dataset name",
       "description": "Dataset name.",
       "example": "ACHM2019_Actigraphy_P01",
       "type": "string"
     },
     "uuid": {
+      "title": "UUID",
       "description": "MD5 hash generated from the `name` field",
       "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
       "type": "string"
     },
     "description": {
+      "title": "Description",
       "description": "Short description of the dataset.",
       "example": "",
       "type": "string"
     },
     "instructions": {
+      "title": "Instructions",
       "description": "Description of the instructions that were given to the study participants prior to or during collection of this data set",
       "type": "object",
       "properties": {
         "verbatim_instruction": {
+          "title": "Verbatim instruction",
           "description": "Verbatim instructions given to participant",
           "example": "",
           "type": "string"
         },
         "wear_time": {
+          "title": "Wear time",
           "description": "Number of days the participants were instructed to wear the actigraph. Fractional values are allowed",
           "example": 21,
           "type": "number",
@@ -69,25 +79,30 @@
       "required": ["wear_time"]
     },
     "contributors": {
+      "title": "Contributors",
       "type": "array",
       "items": {
         "$ref": "#/definitions/person"
       }
     },
     "data_set": {
+      "title": "Dataset",
       "description": "Information about the data collection effort.",
       "type": "object",
       "properties": {
         "period": {
+          "title": "Period",
           "description": "Time period during which the data collection was performed",
           "type": "object",
           "properties": {
             "start_date_time": {
+              "title": "Start datetime",
               "description": "Start date-time for the data collection",
               "type": "string",
               "format": "date-time"
             },
             "ongoing": {
+              "title": "Ongoing?",
               "description": "Indicate if the data collection is still ongoing",
               "type": "boolean"
             }
@@ -108,6 +123,7 @@
                       "const": false
                     },
                     "stop_date_time": {
+                      "title": "Stop datetime",
                       "description": "Stop date-time for the data collection",
                       "type": "string",
                       "format": "date-time"

--- a/dataset.json
+++ b/dataset.json
@@ -61,6 +61,13 @@
         "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/person.json"
       }
     },
+    "acquisitions": {
+      "title": "Acquisitions",
+      "type": "array",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/acquisition.json"
+      }
+    },
     "data_set": {
       "title": "Dataset",
       "description": "Information about the data collection effort.",

--- a/dataset.json
+++ b/dataset.json
@@ -48,7 +48,7 @@
       "title": "Contributors",
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/person.json"
+        "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/person.json"
       }
     },
     "data_set": {

--- a/dataset.json
+++ b/dataset.json
@@ -92,16 +92,30 @@
               "type": "boolean"
             }
           },
-          "if": {
-            "properties": { "ongoing": { "const": true } }
-          },
-          "then": {
-            "properties": {
-              "stop_date_time": {
-                "description": "Stop date-time for the data collection",
-                "type": "string",
-                "format": "date-time"
-              }
+          "dependencies": {
+            "ongoing": {
+              "oneOf": [
+                {
+                  "properties": {
+                    "ongoing": {
+                      "const": true
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "ongoing": {
+                      "const": false
+                    },
+                    "stop_date_time": {
+                      "description": "Stop date-time for the data collection",
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": ["stop_date_time"]
+                }
+              ]
             }
           }
         }

--- a/dataset.json
+++ b/dataset.json
@@ -11,6 +11,16 @@
       "example": "ACHM2019_Actigraphy_P01",
       "type": "string"
     },
+    "device_internal_id": {
+      "title": "Internal ID of Device",
+      "description": "Unique identifier of the device in this dataset",
+      "type": "string"
+    },
+    "participant_internal_id": {
+      "title": "Internal ID of Participant",
+      "description": "Unique identifier of the participant in this dataset",
+      "type": "string"
+    },
     "uuid": {
       "title": "UUID",
       "description": "MD5 hash generated from the `name` field",

--- a/dataset.json
+++ b/dataset.json
@@ -68,7 +68,12 @@
       },
       "required": ["wear_time"]
     },
-    "contributors": { "$ref": "#/definitions/person" },
+    "contributors": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/person"
+      }
+    },
     "data_set": {
       "description": "Information about the data collection effort.",
       "type": "object",

--- a/device.json
+++ b/device.json
@@ -6,42 +6,50 @@
   "type": "object",
   "properties": {
     "uuid": {
+      "title": "UUID",
       "description": "MD5 hash generated from the `name` field.",
       "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
       "type": "string"
     },
     "manufacturer": {
+      "title": "Manufacturer",
       "description": "Manufacturer of the device",
       "example": "",
       "type": "string"
     },
     "model": {
+      "title": "Model",
       "description": "Model of the device",
       "example": "",
       "type": "string"
     },
     "serial_number": {
+      "title": "Serial number",
       "description": "Serial number of the device",
       "example": "",
       "type": "string"
     },
     "device_sensors": {
+      "title": "Device sensors",
       "description": "Sensors included in the device",
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
           "device_sensor_internal_id": {
+            "title": "Internal ID",
             "description": "Internal ID of the sensor",
             "example": "1",
             "type": "number"
           },
           "device_sensor_name": {
+            "title": "Name",
             "description": "Name of the sensor",
             "example": "Motion sensor",
             "type": "string"
           },
           "device_sensor_category": {
+            "title": "Category",
             "description": "Category of data acquired by the sensor",
             "enum": ["motion", "light", "temperature"]
           }

--- a/device.json
+++ b/device.json
@@ -67,7 +67,7 @@
             "then": {
               "properties": {
                 "sensor": {
-                  "$ref": "https://github.com/cdsig/CDSIG-Schema/blob/main/sensor_motion.json"
+                  "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/sensors/sensor_motion.json"
                 }
               },
               "required": ["device_sensor"]
@@ -80,7 +80,7 @@
             "then": {
               "properties": {
                 "sensor": {
-                  "$ref": "https://github.com/cdsig/CDSIG-Schema/blob/main/sensor_light.json"
+                  "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/sensors/sensor_light.json"
                 }
               },
               "required": ["device_sensor"]

--- a/device.json
+++ b/device.json
@@ -5,22 +5,22 @@
   "description": "Information about the data acquisition device",
   "type": "object",
   "properties": {
-    "device_uuid": {
+    "uuid": {
       "description": "MD5 hash generated from the `name` field.",
       "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
       "type": "string"
     },
-    "device_manufacturer": {
+    "manufacturer": {
       "description": "Manufacturer of the device",
       "example": "",
       "type": "string"
     },
-    "device_model": {
+    "model": {
       "description": "Model of the device",
       "example": "",
       "type": "string"
     },
-    "device_serial_number": {
+    "serial_number": {
       "description": "Serial number of the device",
       "example": "",
       "type": "string"

--- a/device.json
+++ b/device.json
@@ -59,34 +59,34 @@
           "device_sensor_name",
           "device_sensor_category"
         ],
-        "allOf": [
-          {
-            "if": {
-              "properties": { "device_sensor_category": { "const": "motion" } }
-            },
-            "then": {
-              "properties": {
-                "sensor": {
-                  "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/sensors/sensor_motion.json"
-                }
+        "dependencies": {
+          "device_sensor_category": {
+            "oneOf": [
+              {
+                "properties": {
+                  "device_sensor_category": {
+                    "enum": ["motion"]
+                  },
+                  "sensor": {
+                    "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/sensors/sensor_motion.json"
+                  }
+                },
+                "required": ["sensor"]
               },
-              "required": ["device_sensor"]
-            }
-          },
-          {
-            "if": {
-              "properties": { "device_sensor_category": { "const": "light" } }
-            },
-            "then": {
-              "properties": {
-                "sensor": {
-                  "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/sensors/sensor_light.json"
-                }
-              },
-              "required": ["device_sensor"]
-            }
+              {
+                "properties": {
+                  "device_sensor_category": {
+                    "enum": ["light"]
+                  },
+                  "sensor": {
+                    "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/sensors/sensor_light.json"
+                  }
+                },
+                "required": ["sensor"]
+              }
+            ]
           }
-        ]
+        }
       },
       "minItems": 1,
       "uniqueItems": true

--- a/device.json
+++ b/device.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/device.json",
   "title": "Acquisition device",
   "description": "Information about the data acquisition device",

--- a/device.json
+++ b/device.json
@@ -67,7 +67,7 @@
             "then": {
               "properties": {
                 "sensor": {
-                  "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/sensors/sensor_motion.json"
+                  "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/sensors/sensor_motion.json"
                 }
               },
               "required": ["device_sensor"]
@@ -80,7 +80,7 @@
             "then": {
               "properties": {
                 "sensor": {
-                  "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/sensors/sensor_light.json"
+                  "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/sensors/sensor_light.json"
                 }
               },
               "required": ["device_sensor"]

--- a/device.json
+++ b/device.json
@@ -51,7 +51,7 @@
           "device_sensor_category": {
             "title": "Category",
             "description": "Category of data acquired by the sensor",
-            "enum": ["motion", "light", "temperature"]
+            "enum": ["motion", "light"]
           }
         },
         "required": [
@@ -81,19 +81,6 @@
               "properties": {
                 "sensor": {
                   "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/sensors/sensor_light.json"
-                }
-              },
-              "required": ["device_sensor"]
-            }
-          },
-          {
-            "if": {
-              "properties": { "device_sensor_category": { "const": "temperature" } }
-            },
-            "then": {
-              "properties": {
-                "sensor": {
-                  "$ref": "https://github.com/cdsig/CDSIG-Schema/blob/main/sensor_temperature.json"
                 }
               },
               "required": ["device_sensor"]

--- a/device.json
+++ b/device.json
@@ -5,10 +5,9 @@
   "description": "Information about the data acquisition device",
   "type": "object",
   "properties": {
-    "uuid": {
-      "title": "UUID",
-      "description": "MD5 hash generated from the `name` field.",
-      "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
+    "internal_id": {
+      "title": "Internal ID",
+      "description": "Unique identifier for this device",
       "type": "string"
     },
     "manufacturer": {
@@ -92,5 +91,5 @@
       "uniqueItems": true
     }
   },
-  "required": ["uuid", "manufacturer", "model", "serial_number"]
+  "required": ["internal_id", "manufacturer", "model", "serial_number"]
 }

--- a/event.json
+++ b/event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/event.json",
   "title": "Event-level metadata (within dataset)",
   "description": "Event definition in the context of actigraphy or light data set",

--- a/event.json
+++ b/event.json
@@ -6,26 +6,31 @@
   "type": "object",
   "properties": {
     "event_id": {
+      "title": "Event ID",
       "description": "The unique identifier for an event",
       "type": "number",
       "minimum": 0,
       "multipleOf" : 1
     },
     "event_name": {
+      "title": "Event name",
       "description": "Name of the event",
       "type": "string"
     },
     "start_date_time": {
+      "title": "Start datetime",
       "description": "Start date-time for an event",
       "type": "string",
       "format": "date-time"
     },
     "stop_date_time": {
+      "title": "Stop datetime",
       "description": "Stop date-time for an event",
       "type": "string",
       "format": "date-time"
     },
     "comment": {
+      "title": "Comment",
       "description": "Comment about an event",
       "type": "string"
     }

--- a/participant.json
+++ b/participant.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/participant.json",
   "definitions": {
     "phenotype": {

--- a/participant.json
+++ b/participant.json
@@ -4,12 +4,15 @@
   "definitions": {
     "phenotype": {
       "type": "object",
+      "title": "Phenotype",
       "properties": {
         "name": {
+          "title": "Name",
           "description": "Phenotype",
           "type": "string"
         },
         "value": {
+          "title": "Value",
           "description": "Value",
           "type": "string"
         }
@@ -25,6 +28,7 @@
     "type": "object",
     "properties": {
       "age": {
+        "title": "Age",
         "description": "Age of the participant",
         "example": "",
         "type": "string"
@@ -35,16 +39,19 @@
         "type": "string"
       },
       "internalid": {
+        "title": "Internal ID",
         "description": "Internal ID",
         "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
         "type": "string"
       },
       "sex": {
+        "title": "Sex",
         "description": "Sex",
         "example": "",
         "type": "string"
       },
       "phenotypes": {
+        "title": "Phenotypes",
         "type": "array",
         "items": {
           "$ref": "#/definitions/phenotype"

--- a/participant.json
+++ b/participant.json
@@ -33,10 +33,9 @@
         "example": "",
         "type": "string"
       },
-      "internalid": {
+      "internal_id": {
         "title": "Internal ID",
-        "description": "Internal ID",
-        "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
+        "description": "Unique identifier for this participant",
         "type": "string"
       },
       "sex": {
@@ -60,5 +59,5 @@
         }
       }
   },
- "required": ["age", "sex"]
+ "required": ["age", "internal_id", "sex"]
 }

--- a/participant.json
+++ b/participant.json
@@ -33,11 +33,6 @@
         "example": "",
         "type": "string"
       },
-      "uuid": {
-        "description": "MD5 hash generated from the `name` field.",
-        "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
-        "type": "string"
-      },
       "internalid": {
         "title": "Internal ID",
         "description": "Internal ID",
@@ -58,5 +53,5 @@
         }
       }
   },
- "required": ["age", "uuid", "sex"]
+ "required": ["age", "sex"]
 }

--- a/participant.json
+++ b/participant.json
@@ -51,6 +51,13 @@
         "items": {
           "$ref": "#/definitions/phenotype"
         }
+      },
+      "events": {
+        "title": "Events",
+        "type": "array",
+        "items": {
+          "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/event.json"
+        }
       }
   },
  "required": ["age", "sex"]

--- a/person.json
+++ b/person.json
@@ -7,39 +7,49 @@
 	"type": "object",
 	"properties": {
 		"name": {
+      "title": "Name",
 			"type": "string"
 		},
 		"role": {
+      "title": "Role",
 			"description": "Role ID(s) according to the Contributor Role Ontology (https://www.ebi.ac.uk/ols/ontologies/cro)",
 			"type": "array",
 			"items": {
+        "title": "Role ID",
 				"description": "Role ID",
 				"type": "string",
 				"pattern": "^((CRO_[0-9]{7})|(CREDIT_[0-9]{8}))$"
 			}
 		},
 		"email": {
+      "title": "Email",
 			"type": "string",
 			"format": "idn-email"
 		},
 		"orcid": {
+      "title": "ORCID identifier",
 			"description": "ORCID identifier",
 			"type": "string",
 			"pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9|X]$"
 		},
 		"institution": {
+      "title": "Institution",
 			"type": "object",
 			"properties": {
 				"name": {
+          "title": "Name",
 					"type": "string"
 				},
 				"street_address": {
+          "title": "Street address",
 					"type": "string"
 				},
 				"city": {
+          "title": "City",
 					"type": "string"
 				},
 				"country": {
+          "title": "Country",
 					"type": "string"
 				}
 			},

--- a/person.json
+++ b/person.json
@@ -11,7 +11,7 @@
 			"type": "string"
 		},
 		"role": {
-      "title": "Role",
+      "title": "Roles",
 			"description": "Role ID(s) according to the Contributor Role Ontology (https://www.ebi.ac.uk/ols/ontologies/cro)",
 			"type": "array",
 			"items": {

--- a/person.json
+++ b/person.json
@@ -19,7 +19,8 @@
 				"description": "Role ID",
 				"type": "string",
 				"pattern": "^((CRO_[0-9]{7})|(CREDIT_[0-9]{8}))$"
-			}
+			},
+      "minItems": 1
 		},
 		"email": {
       "title": "Email",

--- a/person.json
+++ b/person.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://json-schema.org/draft-07/schema",
+	"$schema": "http://json-schema.org/draft-07/schema",
 	"$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/person.json",
 	"title": "Base schema for contributors",
 	"description": "Role and contact information about a person.",

--- a/project.json
+++ b/project.json
@@ -41,7 +41,7 @@
     "contributors": {
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/person.json"
+        "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/person.json"
       }
     },
     "project_status": {

--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/project.json",
   "title": "Project-level metadata",
   "description": "Project-level metadata is metadata that describes the project. A project could be a wider organisational unit of studies. For example, there may be different substudies within a project.",

--- a/project.json
+++ b/project.json
@@ -1,36 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/project.json",
-  "definitions": {
-    "person": {
-      "type": "object",
-      "properties": {
-        "name": { "type": "string" },
-        "role": {
-          "description": "Role ID according to the Contributor Role Ontology (https://www.ebi.ac.uk/ols/ontologies/cro)",
-          "type": "string",
-          "pattern": "^((CRO_[0-9]{7})|(CREDIT_[0-9]{8}))$"
-        },
-        "email": { "type": "string", "format": "idn-email" },
-        "orcid": {
-          "description": "ORCID identifier",
-          "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}$"
-        },
-        "institution": {
-          "type": "object",
-          "properties": {
-            "name":           { "type": "string" },
-            "street_address": { "type": "string" },
-            "city":           { "type": "string" },
-            "country":        { "type": "string" }
-          },
-          "required": ["name", "country"]
-        }
-      },
-      "required": ["name", "role", "institution"]
-    }
-  },
   "title": "Project-level metadata",
   "description": "Project-level metadata is metadata that describes the project. A project could be a wider organisational unit of studies. For example, there may be different substudies within a project.",
   "type": "object",
@@ -71,7 +41,7 @@
     "contributors": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/person"
+        "$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/person.json"
       }
     },
     "project_status": {

--- a/sensors/actigraphydevice.json
+++ b/sensors/actigraphydevice.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/actigraphydevice.json",
   "title": "Specification of actigraphy device",
   "description": "Information about the actigraphy device",

--- a/sensors/sensor_light.json
+++ b/sensors/sensor_light.json
@@ -3,26 +3,33 @@
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/sensor_light.json",
   "definitions": {
     "channel": {
+      "title": "Channel",
       "type": "object",
       "properties": {
         "name": {
+          "title": "Name",
           "description": "Name of the channel",
           "type": "string"
         },
         "description": {
+          "title": "Description",
           "description": "Description of the channel",
           "type": "string"
         },
         "spectral_sensitivity": {
+          "title": "Spectral sensitivity",
           "type": "object",
           "properties": {
             "spectral_sensitivity_calibration_status": {
+              "title": "Calibration status",
               "type": "boolean"
             },
             "spectral_sensitivity_calibration_type": {
+              "title": "Calibration type",
               "type": "string"
             },
             "spectral_sensitivity_calibration_details": {
+              "title": "Calibration details",
               "type": "string"
             }
           },
@@ -30,14 +37,18 @@
         },
         "linearity": {
           "type": "object",
+          "title": "Linearity",
           "properties": {
             "linearity_calibration_status": {
+              "title": "Calibration status",
               "type": "boolean"
             },
             "linearity_calibration_type": {
+              "title": "Calibration type",
               "type": "string"
             },
             "linearity_calibration_details": {
+              "title": "Calibration details",
               "type": "string"
             }
           },
@@ -45,14 +56,18 @@
         },
         "directional_response": {
           "type": "object",
+          "title": "Directional response",
           "properties": {
             "directional_response_calibration_status": {
+              "title": "Calibration status",
               "type": "boolean"
             },
             "directional_response_calibration_type": {
+              "title": "Calibration type",
               "type": "string"
             },
             "directional_response_calibration_details": {
+              "title": "Calibration details",
               "type": "string"
             }
           },
@@ -72,31 +87,37 @@
   "type": "object",
   "properties": {
     "sensor_light_uuid": {
+      "title": "UUID",
       "description": "MD5 hash generated from the `manufacturer+model` field.",
       "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
       "type": "string"
     },
     "sensor_light_manufacturer": {
+      "title": "Manufacturer",
       "description": "Manufacturer of the light sensor",
       "example": "Hamamatsu Photonics Co., Ltd",
       "type": "string"
     },
     "sensor_light_type": {
+      "title": "Type",
       "description": "Type of the light sensor",
       "example": "spectrophotometer",
       "type": "string"
     },
     "sensor_light_model": {
+      "title": "Model",
       "description": "Model of the light sensor",
       "example": "C12666MA",
       "type": "string"
     },
     "sensor_light_serial_number": {
+      "title": "Serial number",
       "description": "Serial number of the light sensor",
       "example": "ABCD-1234",
       "type": "string"
     },
     "sensor_light_channels": {
+      "title": "Light channels",
       "type": "array",
       "items": {
         "$ref": "#/definitions/channel"

--- a/sensors/sensor_light.json
+++ b/sensors/sensor_light.json
@@ -22,7 +22,7 @@
           "properties": {
             "spectral_sensitivity_calibration_status": {
               "title": "Calibration status",
-              "type": "boolean"
+              "enum": ["Calibrated", "Uncalibrated"]
             },
             "spectral_sensitivity_calibration_type": {
               "title": "Calibration type",
@@ -41,7 +41,7 @@
           "properties": {
             "linearity_calibration_status": {
               "title": "Calibration status",
-              "type": "boolean"
+              "enum": ["Calibrated", "Uncalibrated"]
             },
             "linearity_calibration_type": {
               "title": "Calibration type",
@@ -60,7 +60,7 @@
           "properties": {
             "directional_response_calibration_status": {
               "title": "Calibration status",
-              "type": "boolean"
+              "enum": ["Calibrated", "Uncalibrated"]
             },
             "directional_response_calibration_type": {
               "title": "Calibration type",

--- a/sensors/sensor_light.json
+++ b/sensors/sensor_light.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/sensor_light.json",
   "definitions": {
     "channel": {

--- a/sensors/sensor_motion.json
+++ b/sensors/sensor_motion.json
@@ -20,18 +20,18 @@
           "properties": {
             "filter_boundary_lower": {
               "description": "Lower boundary (Hz)",
-              "type": "numeric"
+              "type": "number"
             },
             "filter_boundary_upper": {
               "description": "Upper boundary (Hz)",
-              "type": "numeric"
+              "type": "number"
             }
           },
           "additionalProperties": false,
           "minProperties": 1
         }
       },
-      "required" = ["filter_type", "filter_boundary"]
+      "required": ["filter_type", "filter_boundary"]
     },
     "channel": {
       "type": "object",
@@ -47,11 +47,11 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/filter"
+            "$ref": "#/definitions/filter"
           }
         },
         "range": {
-          "description": "Range of acquisition"
+          "description": "Range of acquisition",
           "type": "object",
           "properties": {
             "range_value_min": {

--- a/sensors/sensor_motion.json
+++ b/sensors/sensor_motion.json
@@ -3,26 +3,32 @@
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/sensor_motion.json",
   "definitions": {
     "filter": {
+      "title": "Filter",
       "description": "Description of the filters applied to the acquired data",
       "type": "object",
       "properties": {
         "filter_type": {
+          "title": "Type",
           "description": "Type of filter",
           "enum": ["low-pass", "band-pass", "high-pass"]
         },
         "filter_order": {
+          "title": "Order",
           "description": "Order of filter",
           "type": "integer"
         },
         "filter_boundary": {
+          "title": "Boundary",
           "description": "Frequency settings of the filter",
           "type": "object",
           "properties": {
             "filter_boundary_lower": {
+              "title": "Lower boundary",
               "description": "Lower boundary (Hz)",
               "type": "number"
             },
             "filter_boundary_upper": {
+              "title": "Upper boundary",
               "description": "Upper boundary (Hz)",
               "type": "number"
             }
@@ -34,45 +40,56 @@
       "required": ["filter_type", "filter_boundary"]
     },
     "channel": {
+      "title": "Channel",
       "type": "object",
       "properties": {
         "name": {
+          "title": "Name",
           "description": "Name of the channel",
           "type": "string"
         },
         "description": {
+          "title": "Description",
           "description": "Description of the channel",
           "type": "string"
         },
         "filters": {
+          "title": "Filters",
           "type": "array",
           "items": {
             "$ref": "#/definitions/filter"
           }
         },
         "range": {
+          "title": "Range",
           "description": "Range of acquisition",
           "type": "object",
           "properties": {
             "range_value_min": {
+              "title": "Minimum",
               "type": "number"
             },
             "range_value_max": {
+              "title": "Maximum",
               "type": "number"
             },
             "range_unit": {
+              "title": "Unit",
               "type": "string"
             }
           },
           "required": ["range_value_min", "range_value_max", "range_unit"]
         },
         "resolution": {
+          "title": "Resolution",
           "type": "object",
           "properties": {
             "resolution_value": {
+              "title": "Value",
               "type": "number"
             },
             "resolution_unit": {
+              "title": "Unit",
               "type": "string"
             }
           },
@@ -92,31 +109,37 @@
   "type": "object",
   "properties": {
     "sensor_motion_uuid": {
+      "title": "UUID",
       "description": "MD5 hash generated from the `manufacturer+model` field.",
       "example": "9b4cef4132e84329bc38dda4b2fa3f5b",
       "type": "string"
     },
     "sensor_motion_manufacturer": {
+      "title": "Manufacturer",
       "description": "Manufacturer of the motion sensor",
       "example": "",
       "type": "string"
     },
     "sensor_motion_type": {
+      "title": "Type",
       "description": "Type of the motion sensor",
       "example": "accelerometer",
       "type": "string"
     },
     "sensor_motion_model": {
+      "title": "Model",
       "description": "Model of the sensor",
       "example": "BMI160",
       "type": "string"
     },
     "sensor_motion_serial_number": {
+      "title": "Serial number",
       "description": "Serial number of the motion sensor",
       "example": "ABCD-1234",
       "type": "string"
     },
     "sensor_motion_channels": {
+      "title": "Channels",
       "type": "array",
       "items": {
         "$ref": "#/definitions/channel"

--- a/sensors/sensor_motion.json
+++ b/sensors/sensor_motion.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/sensor_motion.json",
   "definitions": {
     "filter": {

--- a/study.json
+++ b/study.json
@@ -141,6 +141,13 @@
 			"items": {
 				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/dataset.json"
 			}
+		},
+		"participants": {
+			"title": "Participants",
+			"type": "array",
+			"items": {
+				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/participant.json"
+			}
 		}
 	},
 	"dependencies": {

--- a/study.json
+++ b/study.json
@@ -148,6 +148,13 @@
 			"items": {
 				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/participant.json"
 			}
+		},
+		"devices": {
+			"title": "Devices",
+			"type": "array",
+			"items": {
+				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/device.json"
+			}
 		}
 	},
 	"dependencies": {

--- a/study.json
+++ b/study.json
@@ -134,6 +134,13 @@
 			"items": {
 				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/person.json"
 			}
+		},
+		"datasets": {
+			"title": "Datasets",
+			"type": "array",
+			"items": {
+				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/dataset.json"
+			}
 		}
 	},
 	"dependencies": {

--- a/study.json
+++ b/study.json
@@ -36,7 +36,7 @@
 					"description": "Inclusion criteria for sample group, given as an array of strings",
 					"example": "",
 					"type": "array",
-					"minItems": 0,
+					"minItems": 1,
 					"items": {
 						"type": "string"
 					}

--- a/study.json
+++ b/study.json
@@ -132,7 +132,7 @@
 			"type": "array",
 			"minItems": 1,
 			"items": {
-				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/person.json"
+				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/freerange-updates/person.json"
 			}
 		}
 	},

--- a/study.json
+++ b/study.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://json-schema.org/draft-07/schema",
+	"$schema": "http://json-schema.org/draft-07/schema",
 	"$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/study.json",
 	"$defs": {
 		"group": {

--- a/study.json
+++ b/study.json
@@ -3,30 +3,36 @@
 	"$id": "https://github.com/cdsig/CDSIG-Schema/blob/main/study.json",
 	"$defs": {
 		"group": {
+      "title": "Group",
 			"type": "object",
 			"properties": {
 				"name": {
+					"title": "Group name",
 					"description": "Name of group.",
 					"example": "ACHM patients",
 					"type": "string"
 				},
 				"description": {
+					"title": "Group description",
 					"description": "Description of sample group",
 					"example": "",
 					"type": "string"
 				},
 				"label": {
+					"title": "Group label",
 					"description": "Label of sample group",
 					"example": 0,
 					"type": "integer"
 				},
 				"size": {
+					"title": "Group size",
 					"description": "Group size",
 					"example": 6,
 					"type": "integer",
 					"minimum": 1
 				},
 				"inclusion": {
+					"title": "Inclusion criteria",
 					"description": "Inclusion criteria for sample group, given as an array of strings",
 					"example": "",
 					"type": "array",
@@ -36,6 +42,7 @@
 					}
 				},
 				"exclusion": {
+					"title": "Exclusion criteria",
 					"description": "Exclusion criteria for sample group, given as an array of strings",
 					"example": "",
 					"type": "array",
@@ -53,41 +60,49 @@
 	"type": "object",
 	"properties": {
 		"name": {
+			"title": "Name",
 			"description": "Informative or internal study name",
 			"example": "ACHM2019",
 			"type": "string"
 		},
 		"uuid": {
+			"title": "UUID",
 			"description": "Unique MD5 hash generated from the `name` field",
 			"example": "01d429fd3c4cc02697eea7f3fe838c54",
 			"type": "string"
 		},
 		"prereg_doi": {
+			"title": "Pre-registration document DOI",
 			"description": "DOI (Digital Object Identifier) of pre-registration document describing data collection",
 			"example": "",
 			"type": "string"
 		},
 		"ethics_information": {
+			"title": "Ethics information",
 			"description": "Name of ethics committee and approval number",
 			"example": "",
 			"type": "string"
 		},
 		"clinical_trial": {
+			"title": "Clinical trial",
 			"description": "Is this a registered clinical trial?",
 			"example": false,
 			"type": "boolean"
 		},
 		"description": {
+			"title": "Description",
 			"description": "Short narrative description of the study",
 			"example": "",
 			"type": "string"
 		},
 		"sample": {
+			"title": "Sample",
 			"description": "Short description of the study sample.",
 			"example": "Healthy control participants and ACHM patients",
 			"type": "string"
 		},
 		"groups": {
+			"title": "Groups",
 			"description": "Description of the sample group(s) enrolled or examined in the study",
 			"type": "array",
 			"minItems": 1,
@@ -96,11 +111,13 @@
 			}
 		},
 		"intervention": {
+			"title": "Intervention",
 			"description": "Short description of the study intervention, if any",
 			"example": "",
 			"type": "string"
 		},
 		"keywords": {
+			"title": "Keywords",
 			"description": "Key words describing the study.",
 			"example": ["actigraphy", "congenital achromatopsia", "circadian"],
 			"type": "array",
@@ -110,6 +127,7 @@
 			}
 		},
 		"contributors": {
+			"title": "Contributors",
 			"description": "Study contributors",
 			"type": "array",
 			"minItems": 1,

--- a/study.json
+++ b/study.json
@@ -132,7 +132,7 @@
 			"type": "array",
 			"minItems": 1,
 			"items": {
-				"$ref": "https://github.com/cdsig/CDSIG-Schema/blob/main/person.json"
+				"$ref": "https://raw.githubusercontent.com/cdsig/CDSIG-Schema/main/person.json"
 			}
 		}
 	},

--- a/study.json
+++ b/study.json
@@ -118,20 +118,31 @@
 			}
 		}
 	},
-	"if": {
-		"properties": {
-			"clinical_trial": {
-				"const": true
-			}
-		}
-	},
-	"then": {
-		"properties": {
-			"clinical_trial_id": {
-				"description": "Clinical trial identifier as well as registry",
-				"example": "",
-				"type": "string"
-			}
+	"dependencies": {
+    "clinical_trial": {
+      "oneOf": [
+        {
+          "properties": {
+            "clinical_trial": {
+              "const": false
+            }
+          }
+        },
+        {
+          "properties": {
+            "clinical_trial": {
+              "const": true
+            },
+            "clinical_trial_id": {
+              "title": "Clinical Trial ID",
+              "description": "Clinical trial identifier as well as registry",
+              "example": "",
+              "type": "string"
+            }
+          },
+          "required": ["clinical_trial_id"]
+        }
+      ]
 		}
 	},
 	"required": ["name", "uuid", "clinical_trial", "ethics_information", "sample", "description", "keywords"]


### PR DESCRIPTION
This PR collects the various schema changes we've needed to make while developing the data entry web app.

Summary of changes:

- Add titles to schema files so that we can display human friendly titles in the data entry web application.
- Use dependencies instead of if/then to conditionally display/require extra properties based on the value of another property.
- Use http instead of https to specify the meta-schema in the $schema value.
- Use the external Person schema instead of inline definition in the Project and Dataset schema
- Use GitHub raw URLs to point to external schema so that we can dereference them in code
- Nest datasets, participants and devices within Study schema
- Nest events within Participant schema
- Nest acquisitions within Dataset schema
- Add properties to Dataset schema to link to Participant and Device